### PR TITLE
Fix url for ogp of card components

### DIFF
--- a/pages/cards/_card.vue
+++ b/pages/cards/_card.vue
@@ -173,7 +173,7 @@ export default {
     return data
   },
   head() {
-    const url = 'https://stopcovid19.metro.tokyo.lg.jp'
+    const url = 'https://okinawa.stopcovid19.jp'
     const timestamp = new Date().getTime()
     const ogpImage =
       this.$i18n.locale === 'ja'


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #865 


## ⛏ 変更内容 / Details of Changes
- cards/_card.vueのhead()で取得するURLを https://stopcovid19.metro.tokyo.lg.jp から https://okinawa.stopcovid19.jp に変更

## 📸 スクリーンショット / Screenshots

いずれも https://metatags.io にて https://okinawa.stopcovid19.jp/cards/details-of-confirmed-cases を参照したときに取得できる画面になります。

このPRの変更分は https://ngrok.com/ を利用してlocalhostをexposeさせたものを https://metatags.io で `/cards/details-of-confirmed-cases` を参照させています。

### 変更前

<img src="https://user-images.githubusercontent.com/758704/89095596-969f3880-d40a-11ea-818b-c501a44cdd32.png" height="350px" />

### 変更後

<img src="https://user-images.githubusercontent.com/758704/89095616-be8e9c00-d40a-11ea-9e19-931b3e2f3414.png" height="350px" />

