### PR TITLE
「県警戒レベル判断指標」のカード追加 #1293

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -209,6 +209,10 @@ export default Vue.extend({
         {
           title: this.$t('沖縄県医師会ホームページ'),
           link: 'http://okinawa.med.or.jp/html/covid-19.html'
+        },
+        {
+          title: this.$t('沖縄県 COVID-19 概況'),
+          link: 'https://okinawa-covid19map.netlify.app/'
         }
       ]
     }

--- a/components/cards/OkinawaLandMapCard.vue
+++ b/components/cards/OkinawaLandMapCard.vue
@@ -7,12 +7,14 @@
             class="DataView-Title"
             :class="!!$slots.infoPanel ? 'with-infoPanel' : ''"
           >
-            {{ $t('沖縄県内感染者発生状況') }}
+            {{ $t('県警戒レベル判断指標') }}
           </h3>
-          <div class="mapImage">
-            <img :src="$t('/map/hontou.png')" alt="" />
-            <img :src="$t('/map/ritou.png')" alt="" />
-          </div>
+        </div>
+        <div class="mapImage">
+          <iframe
+            src="https://okinawa-covid19map.netlify.app/cards/indicators"
+            frameborder="0"
+          />
         </div>
       </div>
     </v-card>
@@ -41,11 +43,11 @@ export default {
 </script>
 <style lang="scss">
 .mapImage {
-  img {
-    width: 48%;
-    @include lessThan(959) {
-      width: 100%;
-    }
+  width: 100%;
+  height: 100%;
+  iframe {
+    width: 100%;
+    height: 100%;
   }
 }
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -29,7 +29,7 @@
       <confirmed-cases-attributes-card />
       <confirmed-cases-number-card />
       <!-- <tested-number-card /> -->
-      <!-- <okinawa-land-map-card /> -->
+      <okinawa-land-map-card />
       <!-- <okinawa-land-dynamic-map-card /> -->
 
       <!--<telephone-advisory-reports-number-card />


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #1310

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
-「感染者発生状況」の画像の代わりに「県警戒レベル判断指標」を表示する
https://okinawa-covid19map.netlify.app/
- リンクに「沖縄県 COVID-19 概況」を入れる
## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->

![image](https://i.gyazo.com/5e1fefe906285954d4845cdeffb2ff41.gif)
![image](https://user-images.githubusercontent.com/1308577/124231698-9a23ce00-db4b-11eb-84bf-4cd3b22179b0.png)

